### PR TITLE
Reorganization -  Part 2

### DIFF
--- a/inversion-examples/testCSEM/generateSensitivityMatrix.jl
+++ b/inversion-examples/testCSEM/generateSensitivityMatrix.jl
@@ -23,7 +23,7 @@ meshingParam[3] = itopo
 meshingParam[4] = depth_core
 meshingParam[5] = mincellfactor
   
-pFor = getMaxwellFreqParam(x0,n,h,trx,itopo,meshingParam,linSolParam,fname,doFV,doSE)
+pFor = getMaxwellFreqParam(x0,n,h,trx,itopo,meshingParam,linSolParam,doFV,doSE)
 
 
 toc()

--- a/inversion-examples/testCSEM/parametersForInversion.jl
+++ b/inversion-examples/testCSEM/parametersForInversion.jl
@@ -33,7 +33,6 @@ mincellfactor = 1    # minimum cellsize below topo
 
 
 # parameters for the forward problem
-fname = ""    # leave empty for now
 doFV  = true  # use finite volume (other option FEM for finite elements)
 doSE  = false # SE = sensitivity explicit - store sensitivities and not factorizations
  

--- a/inversion-examples/testCSEM/runMaxFreqUBCInversion.jl
+++ b/inversion-examples/testCSEM/runMaxFreqUBCInversion.jl
@@ -57,7 +57,7 @@ meshingParam[3] = itopo
 meshingParam[4] = depth_core
 meshingParam[5] = mincellfactor
   
-pFor = getMaxwellFreqParam(x0,n,h,trx,itopo,meshingParam,linSolParam,fname,doFV,doSE)
+pFor = getMaxwellFreqParam(x0,n,h,trx,itopo,meshingParam,linSolParam,doFV,doSE)
 
 
 toc()

--- a/inversion-examples/testCSEMSingleMesh/parametersForInversion.jl
+++ b/inversion-examples/testCSEMSingleMesh/parametersForInversion.jl
@@ -33,7 +33,6 @@ mincellfactor = 1    # minimum cellsize below topo
 
 
 # parameters for the forward problem
-fname = ""    # leave empty for now
 doFV  = true  # use finite volume (other option FEM for finite elements)
 doSE  = false # SE = sensitivity explicit - store sensitivities and not factorizations
  

--- a/inversion-examples/testCSEMSingleMesh/runMaxFreqUBCInversionSingleMesh.jl
+++ b/inversion-examples/testCSEMSingleMesh/runMaxFreqUBCInversionSingleMesh.jl
@@ -174,8 +174,8 @@ workerList = workers()
 nw         = length(workerList)
 for i = 1:nFreqs
   if doSE
-  	pFor[i] = initRemoteChannel(getMaxwellFreqParamSE,workerList[i%nw+1],
-                                    M,Sources,Obs[i],fields,frq[i],linSolParam)
+  	pFor[i] = initRemoteChannel(getMaxwellFreqParam,workerList[i%nw+1],
+                                    M,Sources,Obs[i],fields,frq[i],linSolParam;sensitivityMethod=:Explicit)
   else
   	fields = Array(Complex128, 0, 0)
   	pFor[i] = initRemoteChannel(getMaxwellFreqParam,workerList[i%nw+1],

--- a/inversion-examples/testCSEMSingleTensorMesh/parametersForInversion.jl
+++ b/inversion-examples/testCSEMSingleTensorMesh/parametersForInversion.jl
@@ -38,7 +38,6 @@ mincellfactor = 1    # minimum cellsize below topo
 
 
 # parameters for the forward problem
-fname = ""    # leave empty for now
 doFV  = true  # use finite volume (other option FEM for finite elements)
 doSE  = false # SE = sensitivity explicit - store sensitivities and not factorizations
  

--- a/inversion-examples/testCSEMSingleTensorMesh/runMaxFreqUBCInversionSingleMesh.jl
+++ b/inversion-examples/testCSEMSingleTensorMesh/runMaxFreqUBCInversionSingleMesh.jl
@@ -166,8 +166,8 @@ workerList = workers()
 nw         = length(workerList)
 for i = 1:nFreqs
   if doSE
-    pFor[i] = initRemoteChannel(getMaxwellFreqParamSE,workerList[i%nw+1],
-                                    M,Sources,Obs[i],fields,frq[i],linSolParam)
+    pFor[i] = initRemoteChannel(getMaxwellFreqParam,workerList[i%nw+1],
+                                M,Sources,Obs[i],fields,frq[i],linSolParam;sensitivityMethod=:Explicit)
   else
     fields = Array(Complex128, 0, 0)
     pFor[i] = initRemoteChannel(getMaxwellFreqParam,workerList[i%nw+1],

--- a/src/MaxwellFreqParam.jl
+++ b/src/MaxwellFreqParam.jl
@@ -1,6 +1,9 @@
 
 export MaxwellFreqParam, getMaxwellFreqParam
 
+# Supported options for various settings
+supportedSensitivityMethods = [:Implicit; :Explicit]
+
 """
 type MaxwellFrequency.MaxwellFreqParam <: ForwardProbType
 
@@ -14,6 +17,8 @@ Fields:
         - transpose interpolation matrix from fields to receivers
     Fields::Array{Complex128}
         - solution to the fwd problem
+    Sens::Array{Complex128}
+        - field for storage of explicit sensitivities (if required)
     freq:Float64
         - angular frequency (includes 2*pi term)
     Ainv::AbstractSolver
@@ -23,11 +28,13 @@ type MaxwellFreqParam{T} <: ForwardProbType
     Sources::Union{Array{Complex128},Array{Float64},SparseMatrixCSC}
     Obs::Union{Array{Complex128},SparseMatrixCSC}
     Fields::Array{Complex128}
+    Sens::Array{Complex128}
     freq::Float64
     Ainv::AbstractSolver
+    sensitivityMethod::Symbol
 end
 
-Base.copy(P::MaxwellFreqParam) = MaxwellFreqParam(P.M, P.Sources, P.Obs, P.Fields, P.freq, P.Ainv)
+Base.copy(P::MaxwellFreqParam) = MaxwellFreqParam(P.M, P.Sources, P.Obs, P.Fields, P.freq, P.Ainv, P.sensitivityMethod)
 
 """
 function getMaxwellFreqParam
@@ -49,72 +56,17 @@ Required Inputs
 function getMaxwellFreqParam(Mesh::AbstractMesh, 
                              Sources, 
                              Obs, 
-                             fields, 
+                             fields,
                              freq, 
-                             linSolParam::AbstractSolver)
+                             linSolParam::AbstractSolver;
+                             sensitivityMethod::Symbol=:Implicit)
     
+    # Check that user has chosen valid settings for categorical options
+    in(sensitivityMethod,supportedSensitivityMethods) || error("Invalid sensitivity method")
+
     if isempty(fields)
         fields = Array(Complex128,0,0)
     end
 
-    return MaxwellFreqParam(Mesh, Sources, Obs, fields, freq, linSolParam)
-end
-
-export MaxwellFreqParamSE, getMaxwellFreqParamSE
-
-"""
-type MaxwellFrequency.MaxwellFreqParam <: ForwardProbType
-
-defines one MaxwellFrequency problem
-
-Fields:
-
-    Mesh::AbstractMesh
-    Sources::Union{Array{Complex128},Array{Float64},SparseMatrixCSC}
-        - used for calculating rhs   
-    Obs::Union{Array{Complex128},SparseMatrixCSC}
-        - transpose interpolation matrix from fields to receivers
-    Fields::Array{Complex128}
-        - solution to the fwd problem
-    freq:Float64
-        - angular frequency (includes 2*pi term)
-    Ainv::AbstractSolver
-    Sens::Array{Complex128} 
-        - sensitivity matrix
-"""
-type MaxwellFreqParamSE{T} <: ForwardProbType
-    Mesh::T
-    Sources::Union{Array{Complex128},SparseMatrixCSC}
-    Obs::Union{Array{Complex128},SparseMatrixCSC}
-    freq::Float64
-    Ainv::AbstractSolver
-    Sens::Array{Complex128}
-end
-
-"""
-function getMaxwellFreqParamSE
-    
-constructor for MaxwellFreqParamSE
-
-Required Inputs
-
-    Mesh::AbstractMesh
-    Sources::Union{Array{Complex128},Array{Float64},SparseMatrixCSC}
-    Obs::Union{Array{Complex128},SparseMatrixCSC}
-        - transpose interpolation matrix from fields to receivers
-    Fields::Array{Complex128}
-        - solution to the fwd problem
-    freq:Float64
-        - angular frequency (includes 2*pi term)
-    linSolParam::AbstractSolver
-"""
-function getMaxwellFreqParamSE(M::AbstractMesh, 
-                               Sources,
-                               Obs,
-                               freq,
-                               linSolParam::AbstractSolver)
-    
-    Sens = Array(Complex128,0,0)
-    
-    return MaxwellFreqParamSE(M, Sources, Obs, freq, linSolParam, Sens)
+    return MaxwellFreqParam(Mesh, Sources, Obs, fields, Array(Complex128,0,0), freq, linSolParam, sensitivityMethod)
 end

--- a/src/MaxwellFreqParam.jl
+++ b/src/MaxwellFreqParam.jl
@@ -17,7 +17,6 @@ Fields:
     freq:Float64
         - angular frequency (includes 2*pi term)
     Ainv::AbstractSolver
-    fname::AbstractString     -> Not used??
 """
 type MaxwellFreqParam{T} <: ForwardProbType
     Mesh::T
@@ -26,10 +25,9 @@ type MaxwellFreqParam{T} <: ForwardProbType
     Fields::Array{Complex128}
     freq::Float64
     Ainv::AbstractSolver
-    fname::AbstractString
 end
 
-Base.copy(P::MaxwellFreqParam) = MaxwellFreqParam(P.M, P.Sources, P.Obs, P.Fields, P.freq, P.Ainv, P.fname)
+Base.copy(P::MaxwellFreqParam) = MaxwellFreqParam(P.M, P.Sources, P.Obs, P.Fields, P.freq, P.Ainv)
 
 """
 function getMaxwellFreqParam
@@ -47,22 +45,19 @@ Required Inputs
     freq:Float64
         - angular frequency (includes 2*pi term)
     linSolParam::AbstractSolver
-    fname::AbstractString
-        - filename where pfor is stored. Not used??
 """
 function getMaxwellFreqParam(Mesh::AbstractMesh, 
                              Sources, 
                              Obs, 
                              fields, 
                              freq, 
-                             linSolParam::AbstractSolver; 
-                             fname="")
+                             linSolParam::AbstractSolver)
     
     if isempty(fields)
         fields = Array(Complex128,0,0)
     end
 
-    return MaxwellFreqParam(Mesh, Sources, Obs, fields, freq, linSolParam, fname)
+    return MaxwellFreqParam(Mesh, Sources, Obs, fields, freq, linSolParam)
 end
 
 export MaxwellFreqParamSE, getMaxwellFreqParamSE
@@ -86,8 +81,6 @@ Fields:
     Ainv::AbstractSolver
     Sens::Array{Complex128} 
         - sensitivity matrix
-    fname::AbstractString
-        - filename where pfor is stored. Not used??
 """
 type MaxwellFreqParamSE{T} <: ForwardProbType
     Mesh::T
@@ -96,7 +89,6 @@ type MaxwellFreqParamSE{T} <: ForwardProbType
     freq::Float64
     Ainv::AbstractSolver
     Sens::Array{Complex128}
-    fname::AbstractString
 end
 
 """
@@ -115,17 +107,14 @@ Required Inputs
     freq:Float64
         - angular frequency (includes 2*pi term)
     linSolParam::AbstractSolver
-    fname::AbstractString
-        - filename where pfor is stored. Not used??
 """
 function getMaxwellFreqParamSE(M::AbstractMesh, 
                                Sources,
                                Obs,
                                freq,
-                               linSolParam::AbstractSolver;
-                               fname="")
+                               linSolParam::AbstractSolver)
     
     Sens = Array(Complex128,0,0)
     
-    return MaxwellFreqParamSE(M, Sources, Obs, freq, linSolParam, Sens, fname)
+    return MaxwellFreqParamSE(M, Sources, Obs, freq, linSolParam, Sens)
 end

--- a/src/Utils/getMaxwellFreqParamOT.jl
+++ b/src/Utils/getMaxwellFreqParamOT.jl
@@ -15,7 +15,6 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 							 nc=2,
 							 Box::Array{Float64}=[2.0  2; 2  2; 2  4],
 							 linSolParam::AbstractSolver=getMUMPSsolver([],1,0),
-							 fname="",
 							 doFV::Bool=true,doSE=true,ncells=[1e4;2e4;])
 
 	S = getOTMeshFromTxRx(x0,n,h,Srcs,Recs,nf,nc,Box)
@@ -55,9 +54,9 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 		obs[:,k] = sparse(getEdgeIntegralOfPolygonalChain(M,Recs[k],normalize=true))
 	end
 	if doSE
-		pFor = getMaxwellFreqParamSE(M,s,obs,freq,linSolParam,fname=fname)
+		pFor = getMaxwellFreqParamSE(M,s,obs,freq,linSolParam)
 	else
-		pFor =  getMaxwellFreqParam(M,s,obs,[],freq,linSolParam,fname=fname)
+		pFor =  getMaxwellFreqParam(M,s,obs,[],freq,linSolParam)
 	end
 	return pFor
 end
@@ -70,7 +69,6 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 							 freq::Array,
 							 SrcRecMap::SparseMatrixCSC;                # maps receivers to sources
 							 ProbSrcMap::SparseMatrixCSC=speye(length(Srcs)),  # maps sources to pFor's, default: single source
-							 fname="",
 							 nf=2,
 							 nc=2,
 							 Box=[2.0  2; 2  2; 2  4],
@@ -119,7 +117,7 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 					if !all(iFreq.==iFreq[1])
 						error("pFor can only handle one frequency!")
 					end
-					pFor[idx]  = initRemoteChannel(getMaxwellFreqParam,p,x0,n,h,Srcs[[iSrc;]],Recs[[indRec;]],freq[iFreq[1]],nf,nc,Box,linSolParam,fname,doFV,doSE,ncells)
+					pFor[idx]  = initRemoteChannel(getMaxwellFreqParam,p,x0,n,h,Srcs[[iSrc;]],Recs[[indRec;]],freq[iFreq[1]],nf,nc,Box,linSolParam,doFV,doSE,ncells)
 					wait(pFor[idx])
 					probs[p] +=1
 				end
@@ -143,7 +141,6 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
                              itopo::Array,
                              meshingParam::Array,
                              linSolParam::AbstractSolver=getMUMPSsolver([],1,0),
-                             fname="",
                              doFV::Bool=true,
                              doSE=true)
 
@@ -201,9 +198,9 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
     linSolParam = getMUMPSsolver([],1,0)
 
 	if doSE
-		pFor = getMaxwellFreqParamSE(M,Sources,Obs,freq,linSolParam,fname="")
+		pFor = getMaxwellFreqParamSE(M,Sources,Obs,freq,linSolParam)
 	else
-		pFor = getMaxwellFreqParam(M,Sources,Obs,[],freq,linSolParam,fname="")
+		pFor = getMaxwellFreqParam(M,Sources,Obs,[],freq,linSolParam)
 	end
 
     write(STDOUT, @sprintf("    Mesh Size: %10i\n", pFor.Mesh.nc))
@@ -219,7 +216,6 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 							 itopo::Array,
 							 meshingParam::Array,
  							 linSolParam::AbstractSolver=getMUMPSsolver([],1,0),
- 						 	 fname="",
  							 doFV::Bool=true,
 							 doSE=true)
 
@@ -247,7 +243,6 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 											itopo,
 											meshingParam,
 											linSolParam,
-											fname,
 											doFV,
 											doSE)
 				end

--- a/src/Utils/getMaxwellFreqParamOT.jl
+++ b/src/Utils/getMaxwellFreqParamOT.jl
@@ -54,7 +54,7 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
 		obs[:,k] = sparse(getEdgeIntegralOfPolygonalChain(M,Recs[k],normalize=true))
 	end
 	if doSE
-		pFor = getMaxwellFreqParamSE(M,s,obs,freq,linSolParam)
+		pFor = getMaxwellFreqParam(M,s,obs,[],freq,linSolParam,sensitivityMethod=:Explicit)
 	else
 		pFor =  getMaxwellFreqParam(M,s,obs,[],freq,linSolParam)
 	end
@@ -198,7 +198,7 @@ function getMaxwellFreqParam(x0::Array{Float64,1},
     linSolParam = getMUMPSsolver([],1,0)
 
 	if doSE
-		pFor = getMaxwellFreqParamSE(M,Sources,Obs,freq,linSolParam)
+		pFor = getMaxwellFreqParam(M,Sources,Obs,[],freq,linSolParam, sensitivityMethod=:Explicit)
 	else
 		pFor = getMaxwellFreqParam(M,Sources,Obs,[],freq,linSolParam)
 	end

--- a/src/getData.jl
+++ b/src/getData.jl
@@ -12,17 +12,13 @@ function getData(sigma, param::MaxwellFreqParam, doClear::Bool=false)
         w = param.freq
         S = param.Sources
         P = param.Obs
+        Ne, = getEdgeConstraints(param.Mesh)      
         
         A = getMaxwellFreqMatrix(sigma, param)
-
-        Ne, = getEdgeConstraints(param.Mesh)
-        Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-        Msig = Ne' * Msig * Ne
-      
         rhs = (im * w) * (Ne' * S)
         
         param.Ainv.doClear = 1
-        U, param.Ainv = solveMaxFreq(A, rhs, Msig, param.Mesh, w, param.Ainv, 0)
+        U, param.Ainv = solveMaxFreq(A, rhs, sigma, param.Mesh, w, param.Ainv, 0)
         param.Ainv.doClear = 0
       
         U = Ne * U
@@ -59,8 +55,6 @@ function getSensMat(sigma, param)
     P    = param.Obs
     
     Ne, = getEdgeConstraints(param.Mesh)
-    Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-    Msig = Ne' * Msig * Ne
     A = getMaxwellFreqMatrix(sigma, param)
 
     X    = reshape(complex(x),size(P,2),size(U,2),size(x,2))
@@ -68,7 +62,7 @@ function getSensMat(sigma, param)
 
     for i=1:size(U,2)
         Z     = -Ne'*(P*X[:,i,:])
-        Z,    = solveMaxFreq(A,Z,Msig,param.Mesh,w,param.Ainv,1)
+        Z,    = solveMaxFreq(A,Z,sigma,param.Mesh,w,param.Ainv,1)
         u     = U[:,i]
         dAdm  = getdEdgeMassMatrix(param.Mesh,u)
         dAdm  = -im*w*Ne'*dAdm

--- a/src/getData.jl
+++ b/src/getData.jl
@@ -43,11 +43,34 @@ function getData(sigma::Array{Float64,1},param::MaxwellFreqParamSE,doClear::Bool
 	tempParam = getMaxwellFreqParam(param.Mesh,param.Sources,param.Obs,[],param.freq, param.Ainv)
 	param.Sens=[]
 	D,tempParam = getData(sigma,tempParam)
-	ns = size(param.Sources,2)
-	nr = size(param.Obs,2)	
-	v      = zeros(ns*nr)
-	J    = getSensTMatVec(speye(ns*nr),sigma,tempParam)
+	J = getSensMat(sigma, tempParam)
 	param.Sens = J'
 	clear!(tempParam)	
 	return D, param
+end
+
+function getSensMat(sigma, param)
+    x = eye(size(param.Sources,2)*size(param.Obs,2))
+    U    = param.Fields
+    w    = param.freq
+    P    = param.Obs
+    
+    Ne, = getEdgeConstraints(param.Mesh)
+    Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
+    Msig = Ne' * Msig * Ne
+    A = getMaxwellFreqMatrix(sigma, param)
+
+    X    = reshape(complex(x),size(P,2),size(U,2),size(x,2))
+    matv = zeros(Complex128,length(sigma),size(x,2))    
+
+    for i=1:size(U,2)
+        Z     = -Ne'*(P*X[:,i,:])
+        Z,    = solveMaxFreq(A,Z,Msig,param.Mesh,w,param.Ainv,1)
+        u     = U[:,i]
+        dAdm  = getdEdgeMassMatrix(param.Mesh,u)
+        dAdm  = -im*w*Ne'*dAdm
+        matv +=  (dAdm'*Z)
+    end
+    
+    return matv
 end

--- a/src/getData.jl
+++ b/src/getData.jl
@@ -3,51 +3,54 @@ export getData
 
 # = ========= The forward problem ===========================
 
-function getData(sigma,   # conductivity
-	              param::MaxwellFreqParam,
-	              doClear::Bool=false)
-	# Maxwell Forward problem
+function getData(sigma, param::MaxwellFreqParam, doClear::Bool=false)
 	
-	doClearAll=false
+    if param.sensitivityMethod == :Implicit
 
-	w    = param.freq
-	S    = param.Sources
-	P    = param.Obs
-	
-	A = getMaxwellFreqMatrix(sigma, param)
+        doClearAll=false
 
-	Ne,   = getEdgeConstraints(param.Mesh)
-	Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-  	Msig = Ne' * Msig * Ne
-  
-  	rhs = (im * w) * (Ne' * S)
-	
-	param.Ainv.doClear = 1
-	U, param.Ainv = solveMaxFreq(A, rhs, Msig,
-	                             param.Mesh, w, param.Ainv,0)
-	param.Ainv.doClear = 0
-  
-	U = Ne * U
-	D = P' * U
-	
-	param.Fields = U
-	if doClear
-		# clear fields and factorization
-		clear!(param,clearAll=doClearAll)
-	end
-	
-	return D, param # data, MaxwellParam
-end # function getData
+        w = param.freq
+        S = param.Sources
+        P = param.Obs
+        
+        A = getMaxwellFreqMatrix(sigma, param)
 
-function getData(sigma::Array{Float64,1},param::MaxwellFreqParamSE,doClear::Bool=false)
-	tempParam = getMaxwellFreqParam(param.Mesh,param.Sources,param.Obs,[],param.freq, param.Ainv)
-	param.Sens=[]
-	D,tempParam = getData(sigma,tempParam)
-	J = getSensMat(sigma, tempParam)
-	param.Sens = J'
-	clear!(tempParam)	
+        Ne, = getEdgeConstraints(param.Mesh)
+        Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
+        Msig = Ne' * Msig * Ne
+      
+        rhs = (im * w) * (Ne' * S)
+        
+        param.Ainv.doClear = 1
+        U, param.Ainv = solveMaxFreq(A, rhs, Msig, param.Mesh, w, param.Ainv, 0)
+        param.Ainv.doClear = 0
+      
+        U = Ne * U
+        D = P' * U
+        
+        param.Fields = U
+        if doClear
+            # clear fields and factorization
+            clear!(param,clearAll=doClearAll)
+        end
+
+    elseif param.sensitivityMethod == :Explicit
+
+        tempParam = getMaxwellFreqParam(param.Mesh, param.Sources, param.Obs, [], param.freq, param.Ainv)
+        param.Sens=[]
+        D,tempParam = getData(sigma,tempParam)
+        J = getSensMat(sigma, tempParam)
+        param.Sens = J'
+        clear!(tempParam)
+
+    else
+        error("getData: Invalid sensitivity method")
+
+    end
+    	
 	return D, param
 end
+
 
 function getSensMat(sigma, param)
     x = eye(size(param.Sources,2)*size(param.Obs,2))

--- a/src/getSensMatVec.jl
+++ b/src/getSensMatVec.jl
@@ -1,40 +1,43 @@
 import jInv.ForwardShare.getSensMatVec
 export getSensMatVec
 
-# = ========= The forward sensitivity ===========================
-
-function getSensMatVec(x::Vector,
-				   	     sigma::Vector,  # conductivity on fwd mesh
-					        param::MaxwellFreqParam)
-    # Sens Mat Vec for FV disctretization on OcTreeMesh
+function getSensMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
+    # Sens Mat Vec for FV disctretization
     # matv = J*x
-	U    = param.Fields
-	w    = param.freq
-	P    = param.Obs
-	
-    Ne,   = getEdgeConstraints(param.Mesh)
-    Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-    Msig = Ne' * Msig * Ne
-    
-    A = getMaxwellFreqMatrix(sigma, param)
-	
-	matv = zeros(Complex128,size(P,2),size(U,2))
 
-	for i=1:size(U,2)
-		u = U[:,i] 
-		dAdm    = getdEdgeMassMatrix(param.Mesh,u)
-		z       = -im*w*Ne'*dAdm*x
-		z,      = solveMaxFreq(A,z,Msig,param.Mesh,w,param.Ainv,0)
-		z       = vec(Ne*z)
-		matv[:,i] = -P'*z	
-	end
-	return vec(matv)
-end # function getSensMatVec for FV OcTreeMesh
+    if param.sensitivityMethod == :Implicit
 
-function getSensMatVec(x::Vector,sigma::Vector,param::MaxwellFreqParamSE)
-	if isempty(param.Sens)
-		warn("getSensTMatVec: Recomputing data to get sensitvity matrix. This should be avoided.")
-		Dc,param = getData(sigma,param)
-	end
-	return param.Sens*x
+        U = param.Fields
+        w = param.freq
+        P = param.Obs
+        
+        Ne, = getEdgeConstraints(param.Mesh)
+        Msig = getEdgeMassMatrix(param.Mesh, vec(sigma))
+        Msig = Ne' * Msig * Ne
+        
+        A = getMaxwellFreqMatrix(sigma, param)
+        
+        matv = zeros(Complex128, size(P, 2), size(U, 2))
+
+        for i=1:size(U, 2)
+            u = U[:, i] 
+            dAdm = getdEdgeMassMatrix(param.Mesh, u)
+            z = -im*w*Ne'*dAdm*x
+            z, = solveMaxFreq(A, z, Msig, param.Mesh, w, param.Ainv, 0)
+            z = vec(Ne*z)
+            matv[:, i] = -P'*z   
+        end
+
+    elseif param.sensitivityMethod == :Explicit
+
+        if isempty(param.Sens)
+            warn("getSensTMatVec: Recomputing data to get sensitvity matrix. This should be avoided.")
+            Dc,param = getData(sigma,param)
+        end
+        matv = param.Sens*x
+
+    else
+        error("getSensTMatVec: Invalid sensitivity method")
+    end
+    return vec(matv)
 end

--- a/src/getSensMatVec.jl
+++ b/src/getSensMatVec.jl
@@ -10,11 +10,7 @@ function getSensMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
         U = param.Fields
         w = param.freq
         P = param.Obs
-        
         Ne, = getEdgeConstraints(param.Mesh)
-        Msig = getEdgeMassMatrix(param.Mesh, vec(sigma))
-        Msig = Ne' * Msig * Ne
-        
         A = getMaxwellFreqMatrix(sigma, param)
         
         matv = zeros(Complex128, size(P, 2), size(U, 2))
@@ -23,7 +19,7 @@ function getSensMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
             u = U[:, i] 
             dAdm = getdEdgeMassMatrix(param.Mesh, u)
             z = -im*w*Ne'*dAdm*x
-            z, = solveMaxFreq(A, z, Msig, param.Mesh, w, param.Ainv, 0)
+            z, = solveMaxFreq(A, z, sigma, param.Mesh, w, param.Ainv, 0)
             z = vec(Ne*z)
             matv[:, i] = -P'*z   
         end

--- a/src/getSensTMatVec.jl
+++ b/src/getSensTMatVec.jl
@@ -8,10 +8,8 @@ function getSensTMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
         U = param.Fields
         w = param.freq
         P = param.Obs
-      
         Ne, = getEdgeConstraints(param.Mesh)
-        Msig = getEdgeMassMatrix(param.Mesh, vec(sigma))
-        Msig = Ne' * Msig * Ne
+
         A = getMaxwellFreqMatrix(sigma, param)
 
         X    = reshape(complex(x), size(P,2), size(U,2))
@@ -22,7 +20,7 @@ function getSensTMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
             dAdm = getdEdgeMassMatrix(param.Mesh, u)
             dAdm = -im*w*Ne'*dAdm
             z = -Ne'*(P*X[:, i])
-            z, = solveMaxFreq(A, z, Msig, param.Mesh, w, param.Ainv, 1)
+            z, = solveMaxFreq(A, z, sigma, param.Mesh, w, param.Ainv, 1)
             z = vec(z)
             matv += real(dAdm'*z)
         end

--- a/src/getSensTMatVec.jl
+++ b/src/getSensTMatVec.jl
@@ -30,36 +30,6 @@ function getSensTMatVec(x::Vector,sigma::Vector,param::MaxwellFreqParam)
 	return matv
 end
 
-function getSensTMatVec(x::SparseMatrixCSC,sigma::Vector,param::MaxwellFreqParam)
-	# SensT Mat Vec for FV disctretization on OcTree mesh
-	x = full(x)
-	U    = param.Fields
-	w    = param.freq
-	P    = param.Obs
-	
-    Ne, = getEdgeConstraints(param.Mesh)
-    Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-    Msig = Ne' * Msig * Ne
-    A = getMaxwellFreqMatrix(sigma, param)
-
-	X    = reshape(complex(x),size(P,2),size(U,2),size(x,2))
-	matv = zeros(Complex128,length(sigma),size(x,2))	
-
-	for i=1:size(U,2)
-		if !all(X.==0)
-			
-			Z     = -Ne'*(P*X[:,i,:])
-			Z,    = solveMaxFreq(A,Z,Msig,param.Mesh,w,param.Ainv,1)
-			u     = U[:,i] 
-			dAdm  = getdEdgeMassMatrix(param.Mesh,u)
-			dAdm  = -im*w*Ne'*dAdm
-			matv +=  (dAdm'*Z)
-		end
-	end
-	
-	return matv
-end
-
 function getSensTMatVec(x::Vector,sigma::Vector,param::MaxwellFreqParamSE)
 	if isempty(param.Sens)
 		warn("getSensTMatVec: Recomputing data to get sensitvity matrix. This should be avoided.")

--- a/src/getSensTMatVec.jl
+++ b/src/getSensTMatVec.jl
@@ -1,39 +1,41 @@
 import jInv.ForwardShare.getSensTMatVec
 export getSensTMatVec
 
-# = ========= The Transpose sensitivity ===========================
+function getSensTMatVec(x::Vector, sigma::Vector, param::MaxwellFreqParam)
+    # SensT Mat Vec for FV disctretization
 
-function getSensTMatVec(x::Vector,sigma::Vector,param::MaxwellFreqParam)
-# SensT Mat Vec for FV disctretization on OcTree mesh
-	U    = param.Fields
-	w    = param.freq
-	P    = param.Obs
-  
-    Ne, = getEdgeConstraints(param.Mesh)
-    Msig = getEdgeMassMatrix(param.Mesh,vec(sigma))
-    Msig = Ne' * Msig * Ne
-    A = getMaxwellFreqMatrix(sigma, param)
+    if param.sensitivityMethod == :Implicit
+        U = param.Fields
+        w = param.freq
+        P = param.Obs
+      
+        Ne, = getEdgeConstraints(param.Mesh)
+        Msig = getEdgeMassMatrix(param.Mesh, vec(sigma))
+        Msig = Ne' * Msig * Ne
+        A = getMaxwellFreqMatrix(sigma, param)
 
-	X    = reshape(complex(x),size(P,2),size(U,2))
-	matv = zeros(size(sigma))
-  
-	for i=1:size(U,2)
-		u     = U[:,i] 
-		dAdm  = getdEdgeMassMatrix(param.Mesh,u)
-		dAdm  = -im*w*Ne'*dAdm
-		z     = -Ne'*(P*X[:,i])
-		z,    = solveMaxFreq(A,z,Msig,param.Mesh,w,param.Ainv,1)
-		z     = vec(z)
-		matv += real(dAdm'*z)
-	end
-	
-	return matv
-end
+        X    = reshape(complex(x), size(P,2), size(U,2))
+        matv = zeros(size(sigma))
+      
+        for i=1:size(U, 2)
+            u = U[:, i] 
+            dAdm = getdEdgeMassMatrix(param.Mesh, u)
+            dAdm = -im*w*Ne'*dAdm
+            z = -Ne'*(P*X[:, i])
+            z, = solveMaxFreq(A, z, Msig, param.Mesh, w, param.Ainv, 1)
+            z = vec(z)
+            matv += real(dAdm'*z)
+        end
 
-function getSensTMatVec(x::Vector,sigma::Vector,param::MaxwellFreqParamSE)
-	if isempty(param.Sens)
-		warn("getSensTMatVec: Recomputing data to get sensitvity matrix. This should be avoided.")
-		Dc,param = getData(sigma,param)
-	end
-	return real(param.Sens'*x)
+    elseif param.sensitivityMethod == :Explicit
+        if isempty(param.Sens)
+            warn("getSensTMatVec: Recomputing data to get sensitvity matrix. This should be avoided.")
+            Dc, param = getData(sigma, param)
+        end
+        matv = real(param.Sens'*x)
+    else
+        error("getSensMatVec: Invalid sensitivity method")
+    end
+
+    return matv
 end

--- a/src/solveMaxFreq.jl
+++ b/src/solveMaxFreq.jl
@@ -24,7 +24,7 @@ output:
 """
 function solveMaxFreq(A::SparseMatrixCSC, 
                       rhs::Union{Array,SparseMatrixCSC}, 
-                      MsigE::SparseMatrixCSC,
+                      sigma::Vector{Float64},
                       mesh::AbstractMesh,
                       w::Real,
                       linSolParam::AbstractSolver,
@@ -38,7 +38,7 @@ end
 
 function solveMaxFreq(A::SparseMatrixCSC, 
                       rhs::Union{Array,SparseMatrixCSC}, 
-                      MsigE::SparseMatrixCSC,
+                      sigma::Vector{Float64},
                       mesh::AbstractMesh,
                       w::Real,
                       linSolParam::IterativeSolver,
@@ -48,6 +48,10 @@ function solveMaxFreq(A::SparseMatrixCSC,
     if linSolParam.doClear == 1
         MmuN = getNodalMassMatrix(mesh,vec(zeros(mesh.nc).+1/mu0))
         Grad = getNodalGradientMatrix(mesh)
+
+        Ne, = getEdgeConstraints(mesh)
+        MsigE = getEdgeMassMatrix(mesh,vec(sigma))
+        MsigE = Ne' * MsigE * Ne
 
         STBa = Grad*MmuN*Grad'
         Aap = [A + STBa          -(im*w)*MsigE*Grad; 

--- a/test/testMaxwellFwd.jl
+++ b/test/testMaxwellFwd.jl
@@ -21,10 +21,9 @@ Curl     = getCurlMatrix(Mr)
 Sources  = map(Complex{Float64},Curl'*randn(sum(Mr.nf),5))
 freq     = 1e2
 Obs      = Curl'*sprandn(sum(Mr.nf),20,0.001)
-fields   = []
 Ainv     = getMUMPSsolver([],1)
-paramr   = getMaxwellFreqParam(Mr,Sources,Obs,fields,freq,Ainv)
-paramrSE = getMaxwellFreqParamSE(Mr,Sources,Obs,freq,Ainv)
+paramr   = getMaxwellFreqParam(Mr,Sources,Obs,[],freq,Ainv)
+paramrSE = getMaxwellFreqParam(Mr,Sources,Obs,[],freq,Ainv,sensitivityMethod=:Explicit)
 
 # conductivitie
 p = rand(Mr.nc)
@@ -55,7 +54,8 @@ w = getSensTMatVec(vec(u),m,paramr)
 
 # Test explicit sensitivities
 println("Testing regular mesh explicit sensitivities")
-paramrSE  = getMaxwellFreqParamSE(Mr,Sources,Obs,freq,Ainv)
+paramrSE  = getMaxwellFreqParam(Mr,Sources,Obs,[],freq,Ainv,sensitivityMethod=:Explicit)
+
 # Derivative test
 function f1(sigdum)
   d, = getData(sigdum,paramrSE)
@@ -79,7 +79,7 @@ h3 = Mr.h[3]*ones(n[3])
 Mt = getTensorMesh3D(h1,h2,h3)
 
 # call getData
-paramt     = getMaxwellFreqParam(Mt,Sources,Obs,fields,freq,Ainv)
+paramt     = getMaxwellFreqParam(Mt,Sources,Obs,[],freq,Ainv)
 Dt, paramt = getData(m,paramt);
 
 #Test that regular mesh data agree with tensor mesh data
@@ -107,7 +107,7 @@ w = getSensTMatVec(vec(u),m,paramt)
 
 # Test explicit sensitivities
 println("Testing tensor mesh explicit sensitivities")
-paramtSE  = getMaxwellFreqParamSE(Mt,Sources,Obs,freq,Ainv)
+paramtSE  = getMaxwellFreqParam(Mr,Sources,Obs,[],freq,Ainv,sensitivityMethod=:Explicit)
 # Derivative test
 function f3(sigdum)
   d, = getData(sigdum,paramtSE)
@@ -134,7 +134,7 @@ if hasJOcTree
   Mofv  = getOcTreeMeshFV(S,h)
 
   # call getData
-  paramofv       = getMaxwellFreqParam(Mofv,Sources,Obs,fields,freq,Ainv)
+  paramofv       = getMaxwellFreqParam(Mofv,Sources,Obs,[],freq,Ainv)
   Dofv, paramofv = getData(m,paramofv)
   
   #Test that tensor data agree with OcTreeFV data
@@ -161,7 +161,8 @@ if hasJOcTree
   
   #Test explicit sensitivities
   println("Testing OcTree mesh FV explicit sensitivities")
-  paramofvSE  = getMaxwellFreqParamSE(Mofv,Sources,Obs,freq,Ainv)
+  paramofvSE  = getMaxwellFreqParam(Mofv,Sources,Obs,[],freq,Ainv,sensitivityMethod=:Explicit)
+                                    
   #Derivative test
   function f(sigdum)
     d, = getData(sigdum,paramofvSE)

--- a/test/testMaxwellSolvers.jl
+++ b/test/testMaxwellSolvers.jl
@@ -10,15 +10,13 @@ n = [16; 20; 32]
 mesh = getRegularMesh(omega,n)
 
 sigma = rand(mesh.nc)*1e-1
-mu0 = 4*pi*1e-7
 w = 1.0*2*pi
 
 # get Maxwell system
-Curl = getCurlMatrix(mesh)
-Msig = getEdgeMassMatrix(mesh,vec(sigma))
-Mmu  = getFaceMassMatrix(mesh,vec(zeros(mesh.nc).+1/mu0))
-A    = Curl'*Mmu*Curl + 1im*w*Msig
+A = getMaxwellFreqMatrix(sigma, w, mesh)
 
+# Build the rhs
+Curl = getCurlMatrix(mesh)
 rhs = randn(size(A,1)) + 1im*randn(size(A,1))
 rhs = Curl'*(Curl*rhs)
 
@@ -31,12 +29,10 @@ solvers  = [ getJuliaSolver(),
              getMUMPSsolver(), 
              getIterativeSolver(bicgstbIM, maxIter=1000, tol=1e-7) ]
 
-# solvers  = [ getIterativeSolver(bicgstbIM, maxIter=1000, tol=1e-7) ]
-
 for s = solvers
 	println("   testing Maxwell solver for ", typeof(s), "...")
 	tic()
-	xi, = solveMaxFreq(A,rhs,Msig,mesh,w,s)
+	xi, = solveMaxFreq(A,rhs,sigma,mesh,w,s)
 	solveTime = toq()
 	@test norm(A*xi-rhs)/norm(rhs) < 1e-6
 	print("   passed in ",solveTime ," sec!\n")


### PR DESCRIPTION
More reorganization and cleanup of MaxwellFrequency.  Summary of changes:

- Removed the fname field from MaxwellFreqParam.  This was not being used anywhere.

- Added getSensMat function for explicitly generating sensitivity matrix. Removed version of getSensTMatVec that was being used for this previously.

- Removed MaxwellFreqParamSE. Added option to select sensitivity method, similar to what has been implimented in MaxwellTime.

- Slightly reorganized getData/solveMaxFreq to simplify things.